### PR TITLE
Make the GitHub org configurable

### DIFF
--- a/.env-dist
+++ b/.env-dist
@@ -1,3 +1,4 @@
+GITHUB_ORG=MDN-Community-Fork
 CONTENT_ROOT=../content/files
 #CONTENT_TRANSLATED_ROOT=../translated-content/files
 #CONTRIBUTOR_SPOTLIGHT_ROOT=../mdn-contributor-spotlight/contributors

--- a/README.md
+++ b/README.md
@@ -103,11 +103,12 @@ original yari repo):
 When you embark on making a change, do it on a new branch, for example
 `git checkout -b my-new-branch`.
 
-## Hosting a production build of MDN web docs
+## Hosting a production build
 
 First run
 
 ```
+cp .env-dist .env
 yarn build:prepare
 yarn build:dist
 yarn build

--- a/build/spas.ts
+++ b/build/spas.ts
@@ -9,6 +9,8 @@ import got from "got";
 
 import { m2h } from "../markdown/index.js";
 
+import * as dotenv from "dotenv";
+
 import {
   VALID_LOCALES,
   MDN_PLUS_TITLE,
@@ -29,6 +31,8 @@ import { getSlugByBlogPostUrl, splitSections } from "./utils.js";
 import { findByURL } from "../content/document.js";
 import { buildDocument } from "./index.js";
 import { findPostBySlug } from "./blog.js";
+
+export const GITHUB_ORG = process.env.GITHUB_ORG;
 
 const FEATURED_ARTICLES = [
   "blog/regular-expressions-reference-updates/",
@@ -374,7 +378,7 @@ async function fetchGitHubPRs(repo, count = 5) {
 }
 
 async function fetchRecentContributions() {
-  const repos = ["mdn/content", "mdn/translated-content"];
+  const repos = [`${GITHUB_ORG}/content`, `${GITHUB_ORG}/translated-content`];
   const countPerRepo = 5;
   const pullRequests = (
     await Promise.all(

--- a/client/src/document/on-github.tsx
+++ b/client/src/document/on-github.tsx
@@ -1,4 +1,5 @@
 import { Doc } from "../../../libs/types/document";
+import * as dotenv from "dotenv";
 
 export function OnGitHubLink({ doc }: { doc: Doc }) {
   return (
@@ -24,7 +25,7 @@ export function OnGitHubLink({ doc }: { doc: Doc }) {
       </ul>
       Want to get more involved?{" "}
       <a
-        href="https://github.com/mdn/content/blob/main/CONTRIBUTING.md"
+        href={`https://github.com/${process.env.GITHUB_ORG}/content/blob/main/CONTRIBUTING.md`}
         title={`This will take you to our contribution guidelines on GitHub.`}
         target="_blank"
         rel="noopener noreferrer"
@@ -93,12 +94,13 @@ function NewIssueOnGitHubLink({
 }) {
   const { locale } = doc;
   const url = new URL("https://github.com/");
+  const github_org = process.env.GITHUB_ORG;
   const sp = new URLSearchParams();
 
   url.pathname =
     locale !== "en-US"
-      ? "/mdn/translated-content/issues/new"
-      : "/mdn/content/issues/new";
+      ? `/${github_org}/translated-content/issues/new`
+      : `/${github_org}/content/issues/new`;
   sp.set(
     "template",
     locale !== "en-US"

--- a/libs/env/index.js
+++ b/libs/env/index.js
@@ -82,11 +82,13 @@ export const CONTRIBUTOR_SPOTLIGHT_ROOT = correctContentPathFromEnv(
 
 export const BLOG_ROOT = correctContentPathFromEnv("BLOG_ROOT");
 
+export const GITHUB_ORG = process.env.GITHUB_ORG;
+
 // This makes it possible to know, give a root folder, what is the name of
 // the repository on GitHub.
 // E.g. `'https://github.com/' + REPOSITORY_URLS[document.fileInfo.root]`
 export const REPOSITORY_URLS = {
-  [CONTENT_ROOT]: "mdn/content",
+  [CONTENT_ROOT]: `${GITHUB_ORG}/content`,
 };
 
 // Make a combined array of all truthy roots. This way, you don't
@@ -95,7 +97,7 @@ export const REPOSITORY_URLS = {
 export const ROOTS = [CONTENT_ROOT];
 if (CONTENT_TRANSLATED_ROOT) {
   ROOTS.push(CONTENT_TRANSLATED_ROOT);
-  REPOSITORY_URLS[CONTENT_TRANSLATED_ROOT] = "mdn/translated-content";
+  REPOSITORY_URLS[CONTENT_TRANSLATED_ROOT] = `${GITHUB_ORG}translated-content`;
 }
 
 function correctContentPathFromEnv(envVarName) {


### PR DESCRIPTION
This change makes the project’s GitHub org configurable — so that, for example, users will get navigated to the right place when they use the links at the end of each article for the following actions:

  - Edit the page on GitHub
  - View the source on GitHub
  - Learn how to contribute
  - Report the content issue

As an (intended) consequence of this, those links will now go to https://github.com/MDN-Community-Fork/content URLs — but that repo doesn’t actually exist yet. So, before merging this, we should actually fork the https://github.com/mdn/content over — and the https://github.com/MDN-Community-Fork/translated-content repo too, while we’re at it.